### PR TITLE
python3: fix pkgconfig libs bytes to string exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,6 @@ setup(name = "pystatgrab",
         "statgrab",
         statgrab_src,
         extra_compile_args = cflags.split(),
-        extra_link_args = libs.split(),
+        extra_link_args = libs.decode("utf-8").split(),
     )],
 )


### PR DESCRIPTION
This fixes an exception that occurs during build with recent python3.
```
TypeError: sequence item 23: expected str instance, bytes found
```