### PR TITLE
Python 3 fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 pystatgrab NEWS
 http://www.i-scream.org/pystatgrab/
 
+pystatgrab 0.7 (13 April 2016)
+
+ * Add support for Python 3
+
 pystatgrab 0.6 (14 July 2014)
 
  * Support for libstatgrab 0.90+ API

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(name = "pystatgrab",
     ext_modules = [Extension(
         "statgrab",
         statgrab_src,
-        extra_compile_args = cflags.split(),
-        extra_link_args = libs.decode("utf-8").split(),
+        extra_compile_args = cflags.decode('utf-8').split(),
+        extra_link_args = libs.decode('utf-8').split(),
     )],
 )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ import sys
 import os
 
 # version of pystatgrab
-VERSION = "0.6"
+VERSION = "0.7"
 
 # required version of libstatgrab
 LIBSTATGRAB = "0.91"

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,6 @@ setup(name = "pystatgrab",
         "statgrab",
         statgrab_src,
         extra_compile_args = cflags.split(),
-        extra_link_args = libs.split(),
+        extra_link_args = libs.decode("utf-8").split(),
     )],
 )


### PR DESCRIPTION
Fixes to make pystatgrab work with Python 3, and prepare for 0.7 release.